### PR TITLE
Handle form encoded bodies in code samples and TryItLive

### DIFF
--- a/src/components/TryItLive.jsx
+++ b/src/components/TryItLive.jsx
@@ -57,7 +57,8 @@ export default function TryItLive({
       const res = await fetch(liveEndpoint, {
         method,
         headers,
-        body: method === "GET" ? undefined : JSON.stringify(reqInput),
+        body: method === "GET" ? undefined :
+          bodyType === "form" ? new URLSearchParams(reqInput).toString() : JSON.stringify(reqInput),
       });
       let responseText = await res.text();
       setLiveResponse(responseText);


### PR DESCRIPTION
## Summary
- generate cURL/fetch/python snippets for urlencoded and multipart bodies
- send form data from TryItLive when bodyType is `form`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867803d03288326a68e46d31d27d0de