### PR TITLE
Update live request endpoint handling

### DIFF
--- a/src/components/TryItLive.jsx
+++ b/src/components/TryItLive.jsx
@@ -37,7 +37,26 @@ export default function TryItLive({
 
   // Compose endpoint with path/query
   let liveEndpoint = endpoint;
-  // TODO: interpolate path/query params if desired
+  const pathKeys = (endpoint.match(/\{(\w+)\}/g) || []).map((m) =>
+    m.replace(/[{}]/g, "")
+  );
+  liveEndpoint = liveEndpoint.replace(/\{(\w+)\}/g, (_, k) =>
+    reqInput[k] !== undefined ? encodeURIComponent(reqInput[k]) : `{${k}}`
+  );
+
+  if (method === "GET") {
+    const queryPairs = requestParams
+      .filter((p) => !pathKeys.includes(p.name))
+      .map((p) => [p.name, reqInput[p.name]])
+      .filter(([, v]) => v !== undefined && v !== "");
+
+    if (queryPairs.length) {
+      const qs = queryPairs
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&");
+      liveEndpoint += (liveEndpoint.includes("?") ? "&" : "?") + qs;
+    }
+  }
 
   const handleSend = async () => {
     setIsLoading(true);


### PR DESCRIPTION
## Summary
- interpolate path and query parameters when sending live API requests

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68678049bae88326aabb26b1f9a3303a