### PR TITLE
Remove form body support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,11 +23,9 @@ export default function App() {
     response: {},
     meta: { title: "", description: "" },
     integrationNotes: "",
-    bodyType: "raw", // "raw" or "form"
   });
   const [requestParams, setRequestParams] = useState([]);
   const [responseParams, setResponseParams] = useState([]);
-  const [formBody, setFormBody] = useState([{ key: "", value: "" }]);
   const [rawBody, setRawBody] = useState("");
   const [toast, setToast] = useState("");
   const [showNotesPreview, setShowNotesPreview] = useState(false);
@@ -137,50 +135,16 @@ export default function App() {
     return () => document.removeEventListener("mousedown", handler);
   }, [exportOpen]);
 
-  // ---- Body Type Handling ----
-  const handleBodyTypeChange = (type) => {
-    setData(d => ({
-      ...d,
-      bodyType: type,
-      headers: {
-        ...d.headers,
-        "Content-Type": type === "form"
-          ? "application/x-www-form-urlencoded"
-          : (d.headers["Content-Type"] === "application/x-www-form-urlencoded"
-            ? "application/json"
-            : d.headers["Content-Type"] || "application/json"),
-      },
-    }));
-  };
+  // ---- Body Handling ----
 
-  // Whenever Content-Type is changed manually, switch editor mode
-  useEffect(() => {
-    const ct = data.headers["Content-Type"];
-    if (ct === "application/x-www-form-urlencoded" && data.bodyType !== "form") {
-      setData(d => ({ ...d, bodyType: "form" }));
-    }
-    if (ct !== "application/x-www-form-urlencoded" && data.bodyType !== "raw") {
-      setData(d => ({ ...d, bodyType: "raw" }));
-    }
-    // eslint-disable-next-line
-  }, [data.headers["Content-Type"]]);
-
-  // Prepare request body based on editor mode
+  // Prepare request body from raw text
   const getRequestBody = () => {
-    if (data.method === "GET") return undefined;
-    if (data.bodyType === "form") {
-      const obj = {};
-      formBody.forEach(({ key, value }) => { if (key) obj[key] = value; });
-      return obj;
+    if (data.method === "GET" || !rawBody) return undefined;
+    try {
+      return JSON.parse(rawBody);
+    } catch {
+      return rawBody;
     }
-    if (rawBody) {
-      try {
-        return JSON.parse(rawBody);
-      } catch {
-        return rawBody;
-      }
-    }
-    return undefined;
   };
 
   // ---- UI Render ----
@@ -389,34 +353,7 @@ export default function App() {
                     <option value="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
                     <option value="text/plain">text/plain</option>
                   </select>
-                  {/* Body format toggle */}
                   {data.method !== "GET" && (
-                    <div className="mb-2">
-                      <label className="font-semibold mr-2">Body Format:</label>
-                      <label>
-                        <input
-                          type="radio"
-                          name="bodyType"
-                          value="raw"
-                          checked={data.bodyType === "raw"}
-                          onChange={() => handleBodyTypeChange("raw")}
-                        />{" "}
-                        Raw Body
-                      </label>
-                      <label className="ml-4">
-                        <input
-                          type="radio"
-                          name="bodyType"
-                          value="form"
-                          checked={data.bodyType === "form"}
-                          onChange={() => handleBodyTypeChange("form")}
-                        />{" "}
-                        Form (x-www-form-urlencoded)
-                      </label>
-                    </div>
-                  )}
-                  {/* Raw or form editor */}
-                  {data.method !== "GET" && data.bodyType === "raw" && (
                     <textarea
                       className="w-full border px-2 py-2 rounded resize-y text-black dark:text-white bg-white dark:bg-gray-800"
                       rows={4}
@@ -424,48 +361,6 @@ export default function App() {
                       value={rawBody}
                       onChange={e => setRawBody(e.target.value)}
                     />
-                  )}
-                  {data.method !== "GET" && data.bodyType === "form" && (
-                    <div>
-                      {formBody.map((row, idx) => (
-                        <div className="flex gap-2 mb-1" key={idx}>
-                          <input
-                            className="border px-2 py-1 rounded w-1/2"
-                            placeholder="Key"
-                            value={row.key}
-                            onChange={e => {
-                              const updated = [...formBody];
-                              updated[idx].key = e.target.value;
-                              setFormBody(updated);
-                            }}
-                          />
-                          <input
-                            className="border px-2 py-1 rounded w-1/2"
-                            placeholder="Value"
-                            value={row.value}
-                            onChange={e => {
-                              const updated = [...formBody];
-                              updated[idx].value = e.target.value;
-                              setFormBody(updated);
-                            }}
-                          />
-                          <button
-                            className="px-2 rounded text-red-500"
-                            onClick={() => setFormBody(formBody.filter((_, i) => i !== idx))}
-                            type="button"
-                          >
-                            ✕
-                          </button>
-                        </div>
-                      ))}
-                      <button
-                        className="text-xs text-green-600 mt-1 underline"
-                        onClick={() => setFormBody([...formBody, { key: "", value: "" }])}
-                        type="button"
-                      >
-                        + Add Param
-                      </button>
-                    </div>
                   )}
                 </div>
                 {/* Integration notes */}
@@ -578,9 +473,6 @@ export default function App() {
                   method={data.method}
                   headers={actualHeaders}
                   endpoint={actualEndpoint}
-                  bodyType={data.bodyType}
-                  formBody={formBody}
-                  rawBody={rawBody}
                 />
               </div>
             </div>

--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -29,9 +29,7 @@ export default function AutoAnalyzer({
   const [endpoint, setEndpoint] = useState("");
   const [method, setMethod] = useState("GET");
   const [headers, setHeaders] = useState('{"Content-Type": "application/json"}');
-  const [bodyType, setBodyType] = useState("application/json");
   const [bodyJson, setBodyJson] = useState("");
-  const [bodyKeyValues, setBodyKeyValues] = useState([{ key: "", value: "" }]);
   const [queryParams, setQueryParams] = useState([{ name: "", value: "" }]);
   const [pathParams, setPathParams] = useState({});
   const [error, setError] = useState("");
@@ -86,33 +84,19 @@ export default function AutoAnalyzer({
 
     // POST/PUT/PATCH: handle request body and params
     if (["POST", "PUT", "PATCH"].includes(method)) {
-      let contentType = bodyType;
-      parsedHeaders["Content-Type"] = bodyType;
-
-      if (bodyType === "application/json") {
-        let bodyObj;
-        try {
-          bodyObj = bodyJson ? JSON.parse(bodyJson) : null;
-        } catch (e) {
-          setError("Body is not valid JSON.");
-          return;
-        }
-        if (!bodyObj || Object.keys(bodyObj).length === 0) {
-          setError("Please provide a non-empty JSON body.");
-          return;
-        }
-        setRequestParams(flattenSchema(bodyObj));
+      parsedHeaders["Content-Type"] = "application/json";
+      let bodyObj;
+      try {
+        bodyObj = bodyJson ? JSON.parse(bodyJson) : null;
+      } catch (e) {
+        setError("Body is not valid JSON.");
+        return;
       }
-
-      if (bodyType === "application/x-www-form-urlencoded" || bodyType === "multipart/form-data") {
-        const filtered = bodyKeyValues.filter((kv) => kv.key.trim());
-        setRequestParams(filtered.map((kv) => ({
-          name: kv.key,
-          type: "string",
-          required: false,
-          description: bodyType === "multipart/form-data" ? "Form data field" : "Form field",
-        })));
+      if (!bodyObj || Object.keys(bodyObj).length === 0) {
+        setError("Please provide a non-empty JSON body.");
+        return;
       }
+      setRequestParams(flattenSchema(bodyObj));
     }
 
     // GET: handle request params from query
@@ -137,25 +121,7 @@ export default function AutoAnalyzer({
     // Compose body for fetch
     let fetchBody = undefined;
     if (["POST", "PUT", "PATCH"].includes(method)) {
-      if (bodyType === "application/json") {
-        fetchBody = bodyJson;
-      } else if (bodyType === "application/x-www-form-urlencoded") {
-        fetchBody = bodyKeyValues
-          .filter((kv) => kv.key.trim())
-          .map(
-            (kv) =>
-              `${encodeURIComponent(kv.key)}=${encodeURIComponent(kv.value)}`
-          )
-          .join("&");
-      } else if (bodyType === "multipart/form-data") {
-        // For browser fetch, don't set Content-Type for FormData!
-        delete parsedHeaders["Content-Type"];
-        const formData = new FormData();
-        bodyKeyValues
-          .filter((kv) => kv.key.trim())
-          .forEach((kv) => formData.append(kv.key, kv.value));
-        fetchBody = formData;
-      }
+      fetchBody = bodyJson;
     }
 
     try {
@@ -211,18 +177,6 @@ export default function AutoAnalyzer({
     setQueryParams((params) => params.filter((_, i) => i !== idx));
   };
 
-  // Body Key-Value pairs for form-data/x-www-form-urlencoded
-  const handleBodyKVChange = (idx, field, value) => {
-    setBodyKeyValues((items) =>
-      items.map((kv, i) => (i === idx ? { ...kv, [field]: value } : kv))
-    );
-  };
-  const handleAddBodyKV = () => {
-    setBodyKeyValues((items) => [...items, { key: "", value: "" }]);
-  };
-  const handleRemoveBodyKV = (idx) => {
-    setBodyKeyValues((items) => items.filter((_, i) => i !== idx));
-  };
 
   // Path param values UI (auto-generated from endpoint)
   const pathParamsUI =
@@ -355,94 +309,15 @@ export default function AutoAnalyzer({
         />
 
         {(method === "POST" || method === "PUT" || method === "PATCH") && (
-          <>
-            <label className="font-medium">Body Type</label>
-            <select
-              value={bodyType}
-              onChange={(e) => setBodyType(e.target.value)}
-              className="border px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
-            >
-              <option value="application/json">application/json</option>
-              <option value="application/x-www-form-urlencoded">x-www-form-urlencoded</option>
-              <option value="multipart/form-data">multipart/form-data</option>
-            </select>
-
-            {/* Body JSON */}
-            {bodyType === "application/json" && (
-              <>
-                <label className="font-medium">Body (JSON)</label>
-                <textarea
-                  value={bodyJson}
-                  onChange={(e) => setBodyJson(e.target.value)}
-                  className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800"
-                  rows={3}
-                  placeholder='{"key":"value"}'
-                />
-              </>
-            )}
-
-            {/* Body key-values */}
-            {(bodyType === "application/x-www-form-urlencoded" ||
-              bodyType === "multipart/form-data") && (
-              <div className="mb-2">
-                <label className="font-medium">Body Parameters</label>
-                <table className="w-full border mb-2 text-xs mt-1">
-                  <thead>
-                    <tr>
-                      <th className="border px-2 py-1">Key</th>
-                      <th className="border px-2 py-1">Value</th>
-                      <th className="border px-2 py-1"></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {bodyKeyValues.map((param, idx) => (
-                      <tr key={idx}>
-                        <td className="border px-2 py-1">
-                          <input
-                            type="text"
-                            value={param.key}
-                            onChange={(e) =>
-                              handleBodyKVChange(idx, "key", e.target.value)
-                            }
-                            className="w-full border px-1 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
-                            placeholder="key"
-                          />
-                        </td>
-                        <td className="border px-2 py-1">
-                          <input
-                            type="text"
-                            value={param.value}
-                            onChange={(e) =>
-                              handleBodyKVChange(idx, "value", e.target.value)
-                            }
-                            className="w-full border px-1 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
-                            placeholder="value"
-                          />
-                        </td>
-                        <td className="border px-2 py-1">
-                          {bodyKeyValues.length > 1 && (
-                            <button
-                              className="text-red-600 hover:text-red-800 text-xs px-1"
-                              onClick={() => handleRemoveBodyKV(idx)}
-                              title="Remove"
-                            >
-                              ✕
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-                <button
-                  onClick={handleAddBodyKV}
-                  className="bg-gray-200 dark:bg-gray-700 text-xs px-2 py-1 rounded"
-                  type="button"
-                >
-                  + Add Param
-                </button>
-              </div>
-            )}
+          <> 
+            <label className="font-medium">Body (JSON)</label>
+            <textarea
+              value={bodyJson}
+              onChange={(e) => setBodyJson(e.target.value)}
+              className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800"
+              rows={3}
+              placeholder='{"key":"value"}'
+            />
           </>
         )}
 

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -32,9 +32,7 @@ export default function ManualDocEditor({
   // Local state for the fields
   const [endpoint, setEndpoint] = useState(data.baseUrl + (data.path || ""));
   const [method, setMethod] = useState(data.method || "GET");
-  const [bodyType, setBodyType] = useState("application/json");
   const [bodyJson, setBodyJson] = useState("");
-  const [bodyKeyValues, setBodyKeyValues] = useState([{ key: "", value: "" }]);
   const [queryParams, setQueryParams] = useState([{ name: "", value: "" }]);
   const [pathParams, setPathParams] = useState({});
 
@@ -95,27 +93,16 @@ export default function ManualDocEditor({
     }
 
     if (["POST", "PUT", "PATCH"].includes(method)) {
-      if (bodyType === "application/json") {
-        let bodyObj;
-        try {
-          bodyObj = bodyJson ? JSON.parse(bodyJson) : {};
-        } catch {
-          bodyObj = {};
-        }
-        setRequestParams(flattenSchema(bodyObj));
+      let bodyObj;
+      try {
+        bodyObj = bodyJson ? JSON.parse(bodyJson) : {};
+      } catch {
+        bodyObj = {};
       }
-      if (bodyType === "application/x-www-form-urlencoded" || bodyType === "multipart/form-data") {
-        const filtered = bodyKeyValues.filter((kv) => kv.key.trim());
-        setRequestParams(filtered.map((kv) => ({
-          name: kv.key,
-          type: "string",
-          required: false,
-          description: bodyType === "multipart/form-data" ? "Form data field" : "Form field",
-        })));
-      }
+      setRequestParams(flattenSchema(bodyObj));
     }
     // eslint-disable-next-line
-  }, [method, bodyType, bodyJson, bodyKeyValues, queryParams, endpoint]);
+  }, [method, bodyJson, queryParams, endpoint]);
 
   // Query Params table handlers
   const handleQueryParamChange = (idx, field, value) => {
@@ -132,18 +119,6 @@ export default function ManualDocEditor({
     setQueryParams((params) => params.filter((_, i) => i !== idx));
   };
 
-  // Body Key-Value pairs for form-data/x-www-form-urlencoded
-  const handleBodyKVChange = (idx, field, value) => {
-    setBodyKeyValues((items) =>
-      items.map((kv, i) => (i === idx ? { ...kv, [field]: value } : kv))
-    );
-  };
-  const handleAddBodyKV = () => {
-    setBodyKeyValues((items) => [...items, { key: "", value: "" }]);
-  };
-  const handleRemoveBodyKV = (idx) => {
-    setBodyKeyValues((items) => items.filter((_, i) => i !== idx));
-  };
 
   // Path param values UI (auto-generated from endpoint)
   // If you want to collect sample/example values for path params, add input fields below
@@ -262,97 +237,18 @@ export default function ManualDocEditor({
       )}
 
       {/* Body Params for POST/PUT/PATCH */}
-      {(method === "POST" || method === "PUT" || method === "PATCH") && (
-        <>
-          <label className="font-medium">Body Type</label>
-          <select
-            value={bodyType}
-            onChange={(e) => setBodyType(e.target.value)}
-            className="border px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 w-full mb-2"
-          >
-            <option value="application/json">application/json</option>
-            <option value="application/x-www-form-urlencoded">x-www-form-urlencoded</option>
-            <option value="multipart/form-data">multipart/form-data</option>
-          </select>
-
-          {/* Body JSON */}
-          {bodyType === "application/json" && (
-            <>
-              <label className="font-medium">Body (JSON)</label>
-              <textarea
-                value={bodyJson}
-                onChange={(e) => setBodyJson(e.target.value)}
-                className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800 w-full"
-                rows={3}
-                placeholder='{"key":"value"}'
-              />
-            </>
-          )}
-
-          {/* Body key-values */}
-          {(bodyType === "application/x-www-form-urlencoded" ||
-            bodyType === "multipart/form-data") && (
-            <div className="mb-2">
-              <label className="font-medium">Body Parameters</label>
-              <table className="w-full border mb-2 text-xs mt-1">
-                <thead>
-                  <tr>
-                    <th className="border px-2 py-1">Key</th>
-                    <th className="border px-2 py-1">Value</th>
-                    <th className="border px-2 py-1"></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {bodyKeyValues.map((param, idx) => (
-                    <tr key={idx}>
-                      <td className="border px-2 py-1">
-                        <input
-                          type="text"
-                          value={param.key}
-                          onChange={(e) =>
-                            handleBodyKVChange(idx, "key", e.target.value)
-                          }
-                          className="w-full border px-1 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
-                          placeholder="key"
-                        />
-                      </td>
-                      <td className="border px-2 py-1">
-                        <input
-                          type="text"
-                          value={param.value}
-                          onChange={(e) =>
-                            handleBodyKVChange(idx, "value", e.target.value)
-                          }
-                          className="w-full border px-1 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
-                          placeholder="value"
-                        />
-                      </td>
-                      <td className="border px-2 py-1">
-                        {bodyKeyValues.length > 1 && (
-                          <button
-                            className="text-red-600 hover:text-red-800 text-xs px-1"
-                            onClick={() => handleRemoveBodyKV(idx)}
-                            title="Remove"
-                          >
-                            ✕
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <button
-                onClick={handleAddBodyKV}
-                className="bg-gray-200 dark:bg-gray-700 text-xs px-2 py-1 rounded"
-                type="button"
-              >
-                + Add Param
-              </button>
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
+        {(method === "POST" || method === "PUT" || method === "PATCH") && (
+          <>
+            <label className="font-medium">Body (JSON)</label>
+            <textarea
+              value={bodyJson}
+              onChange={(e) => setBodyJson(e.target.value)}
+              className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800 w-full"
+              rows={3}
+              placeholder='{"key":"value"}'
+            />
+          </>
+        )}
+      </div>
+    );
+  }

--- a/src/components/TryItLive.jsx
+++ b/src/components/TryItLive.jsx
@@ -27,7 +27,6 @@ export default function TryItLive({
   method,
   headers,
   endpoint,
-  bodyType,
 }) {
   const [useMock, setUseMock] = useState(false);
   const [reqInput, setReqInput] = useState({});


### PR DESCRIPTION
## Summary
- simplify request body handling in App by removing form type logic
- drop body type logic from analyzer and manual editor
- streamline request body in auto analyzer and manual editor
- update TryItLive props

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686782be5d8883269c0874f14f074422