### PR TITLE
Add DOMPurify sanitation for markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "api-doc-builder-dual-mode",
       "version": "1.0.0",
       "dependencies": {
+        "dompurify": "^3.2.6",
         "html2pdf.js": "^0.10.3",
         "marked": "^15.0.12",
         "react": "^18.2.0",
@@ -1661,7 +1662,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
       "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "dompurify": "^3.2.6",
     "html2pdf.js": "^0.10.3",
     "marked": "^15.0.12",
     "react": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import AutoAnalyzer from "./components/AutoAnalyzer";
 import ManualDocEditor from "./components/ManualDocEditor";
 import ParamsTable from "./components/ParamsTable";
@@ -485,7 +486,9 @@ export default function App() {
                     <div className="prose prose-sm dark:prose-invert bg-gray-50 dark:bg-gray-900 rounded p-3 overflow-auto min-h-[6rem]">
                       <div
                         dangerouslySetInnerHTML={{
-                          __html: marked.parse(data.integrationNotes || ""),
+                          __html: DOMPurify.sanitize(
+                            marked.parse(data.integrationNotes || "")
+                          ),
                         }}
                       />
                     </div>
@@ -555,7 +558,9 @@ export default function App() {
                       <div className="prose prose-sm dark:prose-invert bg-gray-100 dark:bg-gray-900 p-2 rounded">
                         <div
                           dangerouslySetInnerHTML={{
-                            __html: marked.parse(data.integrationNotes || ""),
+                            __html: DOMPurify.sanitize(
+                              marked.parse(data.integrationNotes || "")
+                            ),
                           }}
                         />
                       </div>


### PR DESCRIPTION
## Summary
- install `dompurify`
- sanitize markdown before injecting with `dangerouslySetInnerHTML`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686782bf4a288326889f1a4e5c6fe772