### PR TITLE
Fix endpoint URL parsing

### DIFF
--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -176,10 +176,23 @@ export default function AutoAnalyzer({
 
       setApiResponse(json);
       setResponseParams(flattenSchema(json));
+      let baseUrl = endpointWithPathParams;
+      let path = "";
+      try {
+        const urlObj = new URL(endpointWithPathParams);
+        baseUrl = urlObj.origin;
+        path = urlObj.pathname;
+      } catch {
+        const m = endpointWithPathParams.match(/(https?:\/\/[^/]+)(\/.*)/);
+        if (m) {
+          baseUrl = m[1];
+          path = m[2];
+        }
+      }
       setData((d) => ({
         ...d,
-        baseUrl: endpointWithPathParams.replace(/\/[\w\-]+$/, ""),
-        path: endpointWithPathParams.match(/\/[\w\-]+$/)?.[0] || "",
+        baseUrl,
+        path,
         method,
         headers: parsedHeaders,
         requestBody: fetchBody,

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -44,11 +44,18 @@ export default function ManualDocEditor({
 
   // Sync baseUrl, path and method to data
   useEffect(() => {
-    let pathMatch = endpoint.match(/(https?:\/\/[^/]+)(\/.*)/);
-    let baseUrl = endpoint, path = "";
-    if (pathMatch) {
-      baseUrl = pathMatch[1];
-      path = pathMatch[2];
+    let baseUrl = endpoint;
+    let path = "";
+    try {
+      const urlObj = new URL(endpoint);
+      baseUrl = urlObj.origin;
+      path = urlObj.pathname;
+    } catch {
+      const m = endpoint.match(/(https?:\/\/[^/]+)(\/.*)/);
+      if (m) {
+        baseUrl = m[1];
+        path = m[2];
+      }
     }
     setData((d) => ({
       ...d,


### PR DESCRIPTION
## Summary
- improve endpoint parsing in AutoAnalyzer using URL
- use same URL parsing approach in ManualDocEditor

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68677daba0b08326940a552bbdfdb5eb