### PR TITLE
Fix request header order and sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -276,6 +276,19 @@ export default function App() {
             {/* Main Editor */}
             <div className="grid md:grid-cols-2 gap-10">
               <div className="md:border-r md:pr-8">
+                <RequestSettings
+                  authType={authType}
+                  setAuthType={setAuthType}
+                  authValue={authValue}
+                  setAuthValue={setAuthValue}
+                  contentType={data.headers["Content-Type"] || ""}
+                  setContentType={(val) =>
+                    setData((d) => ({
+                      ...d,
+                      headers: { ...d.headers, "Content-Type": val },
+                    }))
+                  }
+                />
                 {mode === "analyzer" ? (
                   <AutoAnalyzer
                     setData={setData}
@@ -308,25 +321,8 @@ export default function App() {
                   hasRequired={false}
                   editable={true}
                 />
-                <RequestSettings authType={authType} setAuthType={setAuthType} authValue={authValue} setAuthValue={setAuthValue} />
-
-                {/* Content-Type and Body Format */}
+                {/* Request Body */}
                 <div className="mb-6">
-                  <label className="block font-semibold mb-1">Content-Type:</label>
-                  <select
-                    className="border rounded px-2 py-1 bg-white dark:bg-gray-800 mb-2"
-                    value={data.headers["Content-Type"] || ""}
-                    onChange={e =>
-                      setData(d => ({
-                        ...d,
-                        headers: { ...d.headers, "Content-Type": e.target.value }
-                      }))
-                    }
-                  >
-                    <option value="application/json">application/json</option>
-                    <option value="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
-                    <option value="text/plain">text/plain</option>
-                  </select>
                   {data.method !== "GET" && (
                     <textarea
                       className="w-full border px-2 py-2 rounded resize-y text-black dark:text-white bg-white dark:bg-gray-800"

--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -1,19 +1,33 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
 
 export default function AutoAnalyzer({
   setData,
   setRequestParams,
   setResponseParams,
+  headers: incomingHeaders = { "Content-Type": "application/json" },
+  endpoint: incomingEndpoint = "",
 }) {
-  const [endpoint, setEndpoint] = useState("");
+  const [endpoint, setEndpoint] = useState(incomingEndpoint);
   const [method, setMethod] = useState("GET");
-  const [headers, setHeaders] = useState('{"Content-Type": "application/json"}');
+  const [headers, setHeaders] = useState(
+    JSON.stringify(incomingHeaders, null, 2)
+  );
   const [bodyJson, setBodyJson] = useState("");
   const [queryParams, setQueryParams] = useState([{ name: "", value: "" }]);
   const [pathParams, setPathParams] = useState({});
   const [error, setError] = useState("");
   const [apiResponse, setApiResponse] = useState(null);
+
+  // Update local endpoint and headers when incoming props change
+  useEffect(() => {
+    setEndpoint(incomingEndpoint);
+  }, [incomingEndpoint]);
+
+  const incomingHeadersStr = JSON.stringify(incomingHeaders, null, 2);
+  useEffect(() => {
+    setHeaders(incomingHeadersStr);
+  }, [incomingHeadersStr]);
 
   // Compose endpoint with path params
   const endpointWithPathParams = endpoint.replace(/\{(\w+)\}/g, (_, k) => pathParams[k] || `{${k}}`);

--- a/src/components/RequestSettings.jsx
+++ b/src/components/RequestSettings.jsx
@@ -1,36 +1,67 @@
 import React from "react";
 
-export default function RequestSettings({ authType, setAuthType, authValue, setAuthValue }) {
+export default function RequestSettings({
+  authType,
+  setAuthType,
+  authValue,
+  setAuthValue,
+  contentType,
+  setContentType,
+}) {
   return (
     <div className="mb-6">
-      <label className="block font-semibold mb-1">Auth:</label>
-      <div className="flex items-center gap-2">
+      <h3 className="font-semibold mb-2">Request Header</h3>
+      <div className="mb-3">
+        <label className="block font-semibold mb-1">Auth:</label>
+        <div className="flex items-center gap-2">
+          <select
+            className="border rounded px-2 py-1 bg-white dark:bg-gray-800"
+            value={authType}
+            onChange={(e) => {
+              setAuthType(e.target.value);
+              setAuthValue("");
+            }}
+          >
+            <option value="">None</option>
+            <option value="bearer">Bearer Token</option>
+            <option value="apikey-header">API Key (Header)</option>
+            <option value="apikey-query">API Key (Query)</option>
+            <option value="basic">Basic Auth</option>
+          </select>
+          {(authType === "bearer" ||
+            authType === "apikey-header" ||
+            authType === "apikey-query" ||
+            authType === "basic") && (
+            <input
+              className="border rounded px-2 py-1 w-32"
+              value={authValue}
+              onChange={(e) => setAuthValue(e.target.value)}
+              placeholder={
+                authType === "bearer"
+                  ? "Token..."
+                  : authType === "apikey-header"
+                  ? "X-API-KEY..."
+                  : authType === "apikey-query"
+                  ? "api_key=..."
+                  : "user:pass"
+              }
+            />
+          )}
+        </div>
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Content-Type:</label>
         <select
           className="border rounded px-2 py-1 bg-white dark:bg-gray-800"
-          value={authType}
-          onChange={e => {
-            setAuthType(e.target.value);
-            setAuthValue("");
-          }}
+          value={contentType}
+          onChange={(e) => setContentType(e.target.value)}
         >
-          <option value="">None</option>
-          <option value="bearer">Bearer Token</option>
-          <option value="apikey-header">API Key (Header)</option>
-          <option value="apikey-query">API Key (Query)</option>
-          <option value="basic">Basic Auth</option>
+          <option value="application/json">application/json</option>
+          <option value="application/x-www-form-urlencoded">
+            application/x-www-form-urlencoded
+          </option>
+          <option value="text/plain">text/plain</option>
         </select>
-        {(authType === "bearer" || authType === "apikey-header" || authType === "apikey-query" || authType === "basic") && (
-          <input
-            className="border rounded px-2 py-1 w-32"
-            value={authValue}
-            onChange={e => setAuthValue(e.target.value)}
-            placeholder={
-              authType === "bearer" ? "Token..." :
-              authType === "apikey-header" ? "X-API-KEY..." :
-              authType === "apikey-query" ? "api_key=..." : "user:pass"
-            }
-          />
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- group Request Header options with Auth and Content-Type
- move Content-Type dropdown into RequestSettings
- ensure AutoAnalyzer header textarea syncs only when inputs change

## Testing
- `npm install`
- `npx -y vite build`


------
https://chatgpt.com/codex/tasks/task_e_6867874398ac8326a4f7ee8fcae67e27