### PR TITLE
Update request header layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ import Toast from "./components/Toast";
 import TryItLive from "./components/TryItLive";
 import CodeSamples from "./components/CodeSamples";
 import SwaggerExplorerView from "./components/SwaggerExplorerView";
-import RequestSettings from "./components/RequestSettings";
 
 export default function App() {
   // State for projects/endpoints and active endpoint
@@ -315,21 +314,6 @@ export default function App() {
             {/* Main Editor */}
             <div className="grid md:grid-cols-2 gap-10">
               <div className="md:border-r md:pr-8">
-                <RequestSettings
-                  authType={authType}
-                  setAuthType={setAuthType}
-                  authValue={authValue}
-                  setAuthValue={setAuthValue}
- ea3f74-codex/move-request-setting-up-on-page
-                  contentType={data.headers["Content-Type"] || ""}
-                  setContentType={(val) =>
-                    setData((d) => ({
-                      ...d,
-                      headers: { ...d.headers, "Content-Type": val },
-                    }))
-                  }
- main
-                />
                 {mode === "analyzer" ? (
                   <AutoAnalyzer
                     setData={setData}
@@ -337,6 +321,17 @@ export default function App() {
                     setResponseParams={setResponseParams}
                     headers={actualHeaders}
                     endpoint={actualEndpoint}
+                    authType={authType}
+                    setAuthType={setAuthType}
+                    authValue={authValue}
+                    setAuthValue={setAuthValue}
+                    contentType={data.headers["Content-Type"] || ""}
+                    setContentType={(val) =>
+                      setData((d) => ({
+                        ...d,
+                        headers: { ...d.headers, "Content-Type": val },
+                      }))
+                    }
                   />
                 ) : (
                   <ManualDocEditor
@@ -346,6 +341,17 @@ export default function App() {
                     setRequestParams={setRequestParams}
                     responseParams={responseParams}
                     setResponseParams={setResponseParams}
+                    authType={authType}
+                    setAuthType={setAuthType}
+                    authValue={authValue}
+                    setAuthValue={setAuthValue}
+                    contentType={data.headers["Content-Type"] || ""}
+                    setContentType={(val) =>
+                      setData((d) => ({
+                        ...d,
+                        headers: { ...d.headers, "Content-Type": val },
+                      }))
+                    }
                   />
                 )}
                 <ParamsTable

--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
+import RequestSettings from "./RequestSettings";
 
 export default function AutoAnalyzer({
   setData,
@@ -7,6 +8,12 @@ export default function AutoAnalyzer({
   setResponseParams,
   headers: incomingHeaders = { "Content-Type": "application/json" },
   endpoint: incomingEndpoint = "",
+  authType,
+  setAuthType,
+  authValue,
+  setAuthValue,
+  contentType,
+  setContentType,
 }) {
   const [endpoint, setEndpoint] = useState(incomingEndpoint);
   const [method, setMethod] = useState("GET");
@@ -235,6 +242,15 @@ export default function AutoAnalyzer({
             </div>
           </div>
         )}
+
+        <RequestSettings
+          authType={authType}
+          setAuthType={setAuthType}
+          authValue={authValue}
+          setAuthValue={setAuthValue}
+          contentType={contentType}
+          setContentType={setContentType}
+        />
 
         <label className="font-medium">Method</label>
         <select

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
+import RequestSettings from "./RequestSettings";
 
 export default function ManualDocEditor({
   data,
@@ -8,6 +9,12 @@ export default function ManualDocEditor({
   setRequestParams,
   responseParams,
   setResponseParams,
+  authType,
+  setAuthType,
+  authValue,
+  setAuthValue,
+  contentType,
+  setContentType,
 }) {
   // Local state for the fields
   const [endpoint, setEndpoint] = useState(data.baseUrl + (data.path || ""));
@@ -147,6 +154,15 @@ export default function ManualDocEditor({
           </div>
         </div>
       )}
+
+      <RequestSettings
+        authType={authType}
+        setAuthType={setAuthType}
+        authValue={authValue}
+        setAuthValue={setAuthValue}
+        contentType={contentType}
+        setContentType={setContentType}
+      />
 
       <label className="font-medium">Method</label>
       <select


### PR DESCRIPTION
## Summary
- move Auth and Content-Type fields after the Endpoint input
- embed RequestSettings within AutoAnalyzer and ManualDocEditor

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a28cc2bc8326997a26a802139c07