### PR TITLE
Add accessible labels to form fields

### DIFF
--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -201,8 +201,9 @@ export default function AutoAnalyzer({
   return (
     <div className="mb-4">
       <div className="flex flex-col gap-2">
-        <label className="font-medium">Endpoint</label>
+        <label htmlFor="auto-endpoint" className="font-medium">Endpoint</label>
         <input
+          id="auto-endpoint"
           type="text"
           value={endpoint}
           onChange={(e) => setEndpoint(e.target.value)}
@@ -219,6 +220,7 @@ export default function AutoAnalyzer({
                 <div key={key} className="flex items-center gap-1">
                   <span className="font-mono bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">{key}</span>
                   <input
+                    aria-label={`${key} value`}
                     type="text"
                     value={pathParams[key] || ""}
                     onChange={(e) =>
@@ -236,8 +238,9 @@ export default function AutoAnalyzer({
           </div>
         )}
 
-        <label className="font-medium">Method</label>
+        <label htmlFor="auto-method" className="font-medium">Method</label>
         <select
+          id="auto-method"
           value={method}
           onChange={(e) => setMethod(e.target.value)}
           className="border px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800"
@@ -266,6 +269,7 @@ export default function AutoAnalyzer({
                   <tr key={idx}>
                     <td className="border px-2 py-1">
                       <input
+                        aria-label="Query parameter name"
                         type="text"
                         value={param.name}
                         onChange={(e) =>
@@ -277,6 +281,7 @@ export default function AutoAnalyzer({
                     </td>
                     <td className="border px-2 py-1">
                       <input
+                        aria-label="Query parameter value"
                         type="text"
                         value={param.value}
                         onChange={(e) =>
@@ -315,8 +320,9 @@ export default function AutoAnalyzer({
           </div>
         )}
 
-        <label className="font-medium">Headers (JSON)</label>
+        <label htmlFor="auto-headers" className="font-medium">Headers (JSON)</label>
         <textarea
+          id="auto-headers"
           value={headers}
           onChange={(e) => setHeaders(e.target.value)}
           className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800"
@@ -325,9 +331,10 @@ export default function AutoAnalyzer({
         />
 
         {(method === "POST" || method === "PUT" || method === "PATCH") && (
-          <> 
-            <label className="font-medium">Body (JSON)</label>
+          <>
+            <label htmlFor="auto-body" className="font-medium">Body (JSON)</label>
             <textarea
+              id="auto-body"
               value={bodyJson}
               onChange={(e) => setBodyJson(e.target.value)}
               className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800"

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -112,8 +112,9 @@ export default function ManualDocEditor({
 
   return (
     <div>
-      <label className="font-medium">Endpoint</label>
+      <label htmlFor="manual-endpoint" className="font-medium">Endpoint</label>
       <input
+        id="manual-endpoint"
         type="text"
         value={endpoint}
         onChange={(e) => setEndpoint(e.target.value)}
@@ -148,8 +149,9 @@ export default function ManualDocEditor({
         </div>
       )}
 
-      <label className="font-medium">Method</label>
+      <label htmlFor="manual-method" className="font-medium">Method</label>
       <select
+        id="manual-method"
         value={method}
         onChange={(e) => setMethod(e.target.value)}
         className="border px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 w-full mb-2"
@@ -178,6 +180,7 @@ export default function ManualDocEditor({
                 <tr key={idx}>
                   <td className="border px-2 py-1">
                     <input
+                      aria-label="Query parameter name"
                       type="text"
                       value={param.name}
                       onChange={(e) =>
@@ -189,6 +192,7 @@ export default function ManualDocEditor({
                   </td>
                   <td className="border px-2 py-1">
                     <input
+                      aria-label="Query parameter value"
                       type="text"
                       value={param.value}
                       onChange={(e) =>
@@ -226,8 +230,9 @@ export default function ManualDocEditor({
       {/* Body Params for POST/PUT/PATCH */}
         {(method === "POST" || method === "PUT" || method === "PATCH") && (
           <>
-            <label className="font-medium">Body (JSON)</label>
+            <label htmlFor="manual-body" className="font-medium">Body (JSON)</label>
             <textarea
+              id="manual-body"
               value={bodyJson}
               onChange={(e) => setBodyJson(e.target.value)}
               className="border px-2 py-1 rounded font-mono text-black dark:text-white bg-white dark:bg-gray-800 w-full"

--- a/src/components/RequestSettings.jsx
+++ b/src/components/RequestSettings.jsx
@@ -12,9 +12,12 @@ export default function RequestSettings({
     <div className="mb-6">
       <h3 className="font-semibold mb-2">Request Header</h3>
       <div className="mb-3">
-        <label className="block font-semibold mb-1">Auth:</label>
+        <label htmlFor="authType" className="block font-semibold mb-1">
+          Auth:
+        </label>
         <div className="flex items-center gap-2">
           <select
+            id="authType"
             className="border rounded px-2 py-1 bg-white dark:bg-gray-800"
             value={authType}
             onChange={(e) => {
@@ -33,6 +36,7 @@ export default function RequestSettings({
             authType === "apikey-query" ||
             authType === "basic") && (
             <input
+              aria-label="Authentication value"
               className="border rounded px-2 py-1 w-32"
               value={authValue}
               onChange={(e) => setAuthValue(e.target.value)}
@@ -50,8 +54,11 @@ export default function RequestSettings({
         </div>
       </div>
       <div>
-        <label className="block font-semibold mb-1">Content-Type:</label>
+        <label htmlFor="contentType" className="block font-semibold mb-1">
+          Content-Type:
+        </label>
         <select
+          id="contentType"
           className="border rounded px-2 py-1 bg-white dark:bg-gray-800"
           value={contentType}
           onChange={(e) => setContentType(e.target.value)}


### PR DESCRIPTION
## Summary
- add `htmlFor` to Auth and Content-Type select elements
- add labels or `aria-label` to inputs in ManualDocEditor and AutoAnalyzer

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6867a2c4cd3883269959a0ed2bf2bfd8