### PR TITLE
Fix duplicate Request Headers section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -348,17 +348,6 @@ export default function App() {
                     setResponseParams={setResponseParams}
                     headers={actualHeaders}
                     endpoint={actualEndpoint}
-                    authType={authType}
-                    setAuthType={setAuthType}
-                    authValue={authValue}
-                    setAuthValue={setAuthValue}
-                    contentType={data.headers["Content-Type"] || ""}
-                    setContentType={(val) =>
-                      setData((d) => ({
-                        ...d,
-                        headers: { ...d.headers, "Content-Type": val },
-                      }))
-                    }
                   />
                 ) : (
                   <ManualDocEditor
@@ -366,19 +355,6 @@ export default function App() {
                     setData={setData}
                     requestParams={requestParams}
                     setRequestParams={setRequestParams}
-                    responseParams={responseParams}
-                    setResponseParams={setResponseParams}
-                    authType={authType}
-                    setAuthType={setAuthType}
-                    authValue={authValue}
-                    setAuthValue={setAuthValue}
-                    contentType={data.headers["Content-Type"] || ""}
-                    setContentType={(val) =>
-                      setData((d) => ({
-                        ...d,
-                        headers: { ...d.headers, "Content-Type": val },
-                      }))
-                    }
                   />
                 )}
                 <ParamsTable

--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -1,19 +1,12 @@
 import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
 import Spinner from "./Spinner";
-import RequestSettings from "./RequestSettings";
 export default function AutoAnalyzer({
   setData,
   setRequestParams,
   setResponseParams,
   headers: incomingHeaders = { "Content-Type": "application/json" },
   endpoint: incomingEndpoint = "",
-  authType,
-  setAuthType,
-  authValue,
-  setAuthValue,
-  contentType,
-  setContentType,
 }) {
   const [endpoint, setEndpoint] = useState(incomingEndpoint);
   const [method, setMethod] = useState("GET");
@@ -251,16 +244,6 @@ export default function AutoAnalyzer({
         )}
 
         <label htmlFor="auto-method" className="font-medium">Method</label>
-        <RequestSettings
-          authType={authType}
-          setAuthType={setAuthType}
-          authValue={authValue}
-          setAuthValue={setAuthValue}
-          contentType={contentType}
-          setContentType={setContentType}
-        />
-
-        <label className="font-medium">Method</label>
         <select
           id="auto-method"
           value={method}

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -1,20 +1,11 @@
 import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
-import RequestSettings from "./RequestSettings";
 
 export default function ManualDocEditor({
   data,
   setData,
   requestParams,
   setRequestParams,
-  responseParams,
-  setResponseParams,
-  authType,
-  setAuthType,
-  authValue,
-  setAuthValue,
-  contentType,
-  setContentType,
 }) {
   // Local state for the fields
   const [endpoint, setEndpoint] = useState(data.baseUrl + (data.path || ""));
@@ -155,17 +146,7 @@ export default function ManualDocEditor({
           </div>
         </div>
       )}
-      <label htmlFor="manual-method" className="font-medium">Method</label>
-      <RequestSettings
-        authType={authType}
-        setAuthType={setAuthType}
-        authValue={authValue}
-        setAuthValue={setAuthValue}
-        contentType={contentType}
-        setContentType={setContentType}
-      />
-
-      <label className="font-medium">Method</label>
+        <label htmlFor="manual-method" className="font-medium">Method</label>
       <select
         id="manual-method"
         value={method}


### PR DESCRIPTION
## Summary
- remove nested RequestSettings component from manual and auto editors
- clean up unused props in components
- simplify component usage in main app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867a9b68b2c83268e5989de0ae217ee