### PR TITLE
Clean up unused props

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -299,7 +299,7 @@ export default function App() {
               {versions.length > 0 && (
                 <div className="ml-2">
                   <span className="text-xs font-bold text-gray-500 mr-2">Versions:</span>
-                  {versions.map((ver, i) => (
+                  {versions.map((ver) => (
                     <button
                       key={`${ver.name}-${ver.timestamp}`}
                       className="bg-gray-200 dark:bg-gray-700 rounded px-2 py-1 text-xs mx-1"
@@ -364,10 +364,7 @@ export default function App() {
                   <ManualDocEditor
                     data={data}
                     setData={setData}
-                    requestParams={requestParams}
                     setRequestParams={setRequestParams}
-                    responseParams={responseParams}
-                    setResponseParams={setResponseParams}
                     authType={authType}
                     setAuthType={setAuthType}
                     authValue={authValue}
@@ -512,12 +509,9 @@ export default function App() {
                     headers={actualHeaders}
                     params={requestParams.reduce((a, p) => (a[p.name]=p.example||"", a), {})}
                     body={getRequestBody()}
-                    authType={authType}
-                    authValue={authValue}
                   />
                 </div>
                 <TryItLive
-                  data={data}
                   requestParams={requestParams}
                   responseParams={responseParams}
                   method={data.method}

--- a/src/components/CodeSamples.jsx
+++ b/src/components/CodeSamples.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-function makeCode({ endpoint, method, headers, params, body, authType, authValue }) {
+function makeCode({ endpoint, method, headers, params, body }) {
   const contentType = (headers && headers["Content-Type"]) || "";
   let headerLines = Object.entries(headers || {})
     .map(([k, v]) => `-H "${k}: ${v}"`)
@@ -73,10 +73,10 @@ const LANGUAGES = [
   { key: "python", label: "Python" },
 ];
 
-export default function CodeSamples({ endpoint, method, headers, params, body, authType, authValue }) {
+export default function CodeSamples({ endpoint, method, headers, params, body }) {
   const [lang, setLang] = useState("curl");
 
-  const codes = makeCode({ endpoint, method, headers, params, body, authType, authValue });
+  const codes = makeCode({ endpoint, method, headers, params, body });
 
   function handleCopy() {
     navigator.clipboard.writeText(codes[lang]);

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -5,10 +5,7 @@ import RequestSettings from "./RequestSettings";
 export default function ManualDocEditor({
   data,
   setData,
-  requestParams,
   setRequestParams,
-  responseParams,
-  setResponseParams,
   authType,
   setAuthType,
   authValue,
@@ -21,7 +18,6 @@ export default function ManualDocEditor({
   const [method, setMethod] = useState(data.method || "GET");
   const [bodyJson, setBodyJson] = useState("");
   const [queryParams, setQueryParams] = useState([{ name: "", value: "" }]);
-  const [pathParams, setPathParams] = useState({});
 
   // Path Params handling
   const pathParamsUI =
@@ -137,16 +133,6 @@ export default function ManualDocEditor({
             {pathParamsUI.map((key) => (
               <div key={key} className="flex items-center gap-1">
                 <span className="font-mono bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">{key}</span>
-                {/* Optionally add sample value field */}
-                {/* <input
-                  type="text"
-                  value={pathParams[key] || ""}
-                  onChange={(e) =>
-                    setPathParams((prev) => ({ ...prev, [key]: e.target.value }))
-                  }
-                  className="border px-1 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 w-24"
-                  placeholder="value"
-                /> */}
               </div>
             ))}
           </div>

--- a/src/components/SwaggerExplorerView.jsx
+++ b/src/components/SwaggerExplorerView.jsx
@@ -32,8 +32,6 @@ export default function SwaggerExplorerView({ endpoints }) {
               headers={ep.headers || {}}
               params={(ep.requestParams || []).reduce((a, p) => (a[p.name]=p.example||"", a), {})}
               body={ep.requestBody}
-              authType={ep.authType}
-              authValue={ep.authValue}
             />
           </div>
         </details>

--- a/src/components/TryItLive.jsx
+++ b/src/components/TryItLive.jsx
@@ -22,7 +22,6 @@ function mockResponseFromParams(params) {
 }
 
 export default function TryItLive({
-  data,
   requestParams,
   responseParams,
   method,


### PR DESCRIPTION
## Summary
- remove unused parameter from `versions.map`
- drop unused parameters from `ManualDocEditor`
- streamline `CodeSamples` API
- remove unused prop from `TryItLive`
- update usages to match

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867aa2ab0c483269cfa1600a7aa33b3