### PR TITLE
Improve Toast accessibility

### DIFF
--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -4,9 +4,16 @@ import PropTypes from "prop-types";
 export default function Toast({ message, onClose }) {
   if (!message) return null;
   return (
-    <div className="fixed bottom-4 right-4 z-50 bg-green-600 text-white px-4 py-2 rounded shadow-lg flex items-center gap-2">
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed bottom-4 right-4 z-50 bg-green-600 text-white px-4 py-2 rounded shadow-lg flex items-center gap-2"
+    >
       <span>{message}</span>
-      <button onClick={onClose} className="ml-2 font-bold text-lg leading-none focus:outline-none">
+      <button
+        onClick={onClose}
+        className="ml-2 font-bold text-lg leading-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
         ×
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add `role` and `aria-live` attributes to `Toast`
- show visible focus style on the close button

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867aa2d8cb08326975d32ce1f9be60a