### PR TITLE
Fix new lint warnings

### DIFF
--- a/src/components/AutoAnalyzer.jsx
+++ b/src/components/AutoAnalyzer.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import flattenSchema from "../utils/flattenSchema";
 import Spinner from "./Spinner";
-import RequestSettings from "./RequestSettings";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneLight, oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 

--- a/src/components/ManualDocEditor.jsx
+++ b/src/components/ManualDocEditor.jsx
@@ -5,12 +5,6 @@ export default function ManualDocEditor({
   data,
   setData,
   setRequestParams,
-  authType,
-  setAuthType,
-  authValue,
-  setAuthValue,
-  contentType,
-  setContentType,
 }) {
   // Local state for the fields
   const [endpoint, setEndpoint] = useState(data.baseUrl + (data.path || ""));


### PR DESCRIPTION
## Summary
- remove unused `RequestSettings` import in AutoAnalyzer
- drop unused props from ManualDocEditor

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867a92e11048326a9cb4b8214065852